### PR TITLE
[12.0] Removendo dependencia do stock

### DIFF
--- a/sale_direct_sale/__manifest__.py
+++ b/sale_direct_sale/__manifest__.py
@@ -15,8 +15,8 @@
         'sale_margin',
         'sale_margin_supplierinfo_cost',
         'product_pricelist_supplierinfo',
-        'stock_picking_sale_order_link',
-        'stock_dropshipping_from_sale_order'
+        # 'stock_picking_sale_order_link',
+        # 'stock_dropshipping_from_sale_order'
     ],
     'data': [
         'views/sale_order.xml',

--- a/sale_direct_sale/models/sale_order_line.py
+++ b/sale_direct_sale/models/sale_order_line.py
@@ -8,22 +8,14 @@ class SaleOrderLine(models.Model):
 
     _inherit = 'sale.order.line'
 
-    route_id = fields.Many2one(
-        'stock.location.route', string='Route',
-        ondelete='restrict', readonly=True, track_visibility='onchange',
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-        domain=[('sale_selectable', '=', True)], check_company=True)
+    # route_id = fields.Many2one(
+    #     'stock.location.route', string='Route',
+    #     ondelete='restrict', readonly=True, track_visibility='onchange',
+    #     states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
+    #     domain=[('sale_selectable', '=', True)], check_company=True)
 
     direct_sale = fields.Boolean(
-        related='route_id.direct_sale',
+        #related='route_id.direct_sale',
         store=True,
-        readonly=True,
         string='Direct Sale',
-    )
-
-    direct_sale_confirm = fields.Boolean(
-        related='move_ids.rule_id.route_id.direct_sale',
-        store=True,
-        readonly=True,
-        string='Direct Sale Confirm',
     )

--- a/sale_direct_sale/views/sale_order.xml
+++ b/sale_direct_sale/views/sale_order.xml
@@ -9,15 +9,18 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/form//field[@name='route_id']" position="replace">
-                <field name="route_id" options="{'no_create': True}" required="True"/>
-            </xpath>
-            <xpath expr="//field[@name='order_line']/tree/field[@name='route_id']" position="replace">
-                <field name="route_id" options="{'no_create': True}" required="True"/>
-            </xpath>
-<!--            <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="before">-->
-<!--                <field name="route_id" options="{'no_create': True}"/>-->
+<!--            <xpath expr="//field[@name='order_line']/form//field[@name='route_id']" position="replace">-->
+<!--                <field name="route_id" options="{'no_create': True}" required="True"/>-->
 <!--            </xpath>-->
+<!--            <xpath expr="//field[@name='order_line']/tree/field[@name='route_id']" position="replace">-->
+<!--                <field name="route_id" options="{'no_create': True}" required="True"/>-->
+<!--            </xpath>-->
+            <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
+                <field name="direct_sale"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree/field[@name='price_subtotal']" position="after">
+                <field name="direct_sale"/>
+            </xpath>
 
         </field>
     </record>


### PR DESCRIPTION
Deixei o módulo independente do stock afim de permitir que sejam gerenciados pedidos de venda com itens de venda direta mesmo que a empresa nao queria gerenciar a ordem de entrega