### PR TITLE
[14.0][REF] l10n_br_sale_hide_tax_report: change class to hasClass

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+            python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v1

--- a/l10n_br_sale_hide_tax_report/report/sale_report_templates.xml
+++ b/l10n_br_sale_hide_tax_report/report/sale_report_templates.xml
@@ -49,28 +49,28 @@
         </xpath>
         <!-- HIDDE COLUMN TH_TAXES -->
         <xpath
-            expr="//table[@class='table table-sm o_main_table']/thead//th[@name='th_taxes']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]/thead//th[@name='th_taxes']"
             position="attributes"
         >
             <attribute name="class">d-none</attribute>
         </xpath>
         <!-- HIDDE COLUMN TD_TAXES -->
         <xpath
-            expr="//table[@class='table table-sm o_main_table']/tbody//td[@name='td_taxes']"
+            expr="//table[hasclass('table', 'table-sm','o_main_table')]/tbody//td[@name='td_taxes']"
             position="attributes"
         >
             <attribute name="class">d-none</attribute>
         </xpath>
         <!-- HIDDEN SPAN LINE.PRICE_SUBTOTAL (NO INCLUDE TAXES) -->
         <xpath
-            expr="//table[@class='table table-sm o_main_table']/tbody//span[@t-field='line.price_subtotal']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]/tbody//span[@t-field='line.price_subtotal']"
             position="attributes"
         >
             <attribute name="class">d-none</attribute>
         </xpath>
         <!-- REMOVE GROUPS IN LINE.PRICE_TOTAL (INCLUDE TAXES) -->
         <xpath
-            expr="//table[@class='table table-sm o_main_table']/tbody//span[@t-field='line.price_total']"
+            expr="//table[hasclass('table', 'table-sm', 'o_main_table')]/tbody//span[@t-field='line.price_total']"
             position="attributes"
         >
             <attribute name="groups" />


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @Matthwhy 

Refatoração para tratar o warning:

`Error-prone use of @class in view report_saleorder_document_l10n_br_sale_custom (l10n_br_sale_hide_tax_report.report_saleorder_document_l10n_br_sale_custom): use the hasclass(*classes) function to filter elements by their classes `