### PR TITLE
[FIX] test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           for reqfile in requirements.txt test-requirements.txt ; do
               if [ -f ${reqfile} ] ; then
                   result=0
-                  # reject non-comment lines that contain a / (i.e. URLs, relative paths)
-                  grep "^[^#].*/" ${reqfile} || result=$?
+                  # Customization Escodoo
+                  grep "^[^#].*pypi.org" ${reqfile} || result=$?
                   if [ $result -eq 0 ] ; then
                       echo "Unreleased dependencies found in ${reqfile}."
                       exit 1


### PR DESCRIPTION
cc @marcelsavegnago @kaynnan @WesleyOliveira98

objetivo dessa PR é deixar o teste Dependências verdinho, quando aponta um modulo de outro repositorio