### PR TITLE
[16.0][FIX] ‎sale_blanket_order_custom: fix analytic_distribution

### DIFF
--- a/sale_blanket_order_custom/wizard/__init__.py
+++ b/sale_blanket_order_custom/wizard/__init__.py
@@ -1,2 +1,3 @@
+from . import sale_blanket_order_wizard
 from . import sale_create_order_plan
 from . import sale_make_planned_order

--- a/sale_blanket_order_custom/wizard/sale_blanket_order_wizard.py
+++ b/sale_blanket_order_custom/wizard/sale_blanket_order_wizard.py
@@ -1,0 +1,15 @@
+# Copyright 2026 - TODAY, Cristiano Mafra Junior <cristiano.mafra@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleBlanketOrderWizard(models.TransientModel):
+    _inherit = "sale.blanket.order.wizard"
+
+    def _prepare_so_line_vals(self, line):
+        vals = super()._prepare_so_line_vals(line)
+        analytic_account = line.blanket_line_id.analytic_account_id
+        if analytic_account:
+            vals["analytic_distribution"] = {analytic_account.id: 100}
+        return vals


### PR DESCRIPTION
Correção para trazer linha analitica no pedido de venda a partir do pedido guarda-chuva

<img width="1200" height="864" alt="print_02" src="https://github.com/user-attachments/assets/25449620-4e49-41ce-b1db-85a4b5c1d217" />
<img width="1250" height="871" alt="print_01" src="https://github.com/user-attachments/assets/5ad541b7-063a-48cc-a4f1-a998994235b6" />
<img width="1251" height="872" alt="print_03" src="https://github.com/user-attachments/assets/ca563144-ba5d-4aac-8b55-b2559c6f6bfe" />
