### PR TITLE
[16.0][FIX] sale_blanket_order_custom: sudo search

### DIFF
--- a/sale_blanket_order_custom/models/sale_blanket_orders.py
+++ b/sale_blanket_order_custom/models/sale_blanket_orders.py
@@ -77,7 +77,7 @@ class SaleBlanketOrder(models.Model):
 
     def _compute_mis_cash_flow_forecast_line_ids(self):
         ForecastLine = self.env["mis.cash_flow.forecast_line"]
-        forecast_lines = ForecastLine.search(
+        forecast_lines = ForecastLine.sudo().search(
             [
                 ("res_model", "=", self._name),
                 ("res_id", "in", self.ids),


### PR DESCRIPTION
Aplicar sudo() na resolução do ir.model dentro do compute _compute_mis_cash_flow_forecast_line_ids, linha 80 do arquivo sale_blanket_order_custom/models/sale_blanket_orders.py, evitando domínio via res_model_id.model que exige permissão técnica em ir.model.

cc @WesleyOliveira98 