### PR TITLE
[16.0][FIX] sale_blanket_order_custom: preserve remaining_qty precision

### DIFF
--- a/sale_blanket_order_custom/models/sale_blanket_orders.py
+++ b/sale_blanket_order_custom/models/sale_blanket_orders.py
@@ -301,3 +301,20 @@ class BlanketOrderLine(models.Model):
         related="order_id.analytic_account_id",
         string="Analytic Account",
     )
+
+    def _compute_quantities(self):
+        """``remaining_qty`` is force-rounded by the base module to the
+        precision of ``product_id.uom_id.rounding`` (0.01 by default,
+        unrelated to the "Product Unit of Measure" decimal precision
+        that already makes ``remaining_uom_qty`` precise), silently
+        losing the fractional balance needed to sequence progressive
+        measurements (e.g. 1.00 - 0.633 = 0.367 becomes 0.36/0.37).
+        Recompute it without forcing that extra rounding, so it follows
+        the same precision as the rest of the quantity fields.
+        """
+        res = super()._compute_quantities()
+        for line in self:
+            line.remaining_qty = line.product_uom._compute_quantity(
+                line.remaining_uom_qty, line.product_id.uom_id, round=False
+            )
+        return res

--- a/sale_blanket_order_custom/tests/test_sale_blanket_order_custom.py
+++ b/sale_blanket_order_custom/tests/test_sale_blanket_order_custom.py
@@ -22,6 +22,56 @@ class TestSaleBlanketOrderCustom(SaleBlanketOrderCommon, TransactionCase):
         cls.pricelist = cls.pricelist
         cls.blanket = cls.blanket
 
+    def test_remaining_qty_precision_survives_uom_rounding(self):
+        """remaining_qty must not be truncated by an extra, independent
+        rounding step against the product's reference UoM `rounding`
+        (0.01 by default) on top of whatever precision the blanket
+        line's own UoM already uses - mirroring the real case of a
+        fine-grained measurement unit (e.g. "GB", "Mes") on the line
+        versus a coarser generic reference UoM on the product.
+
+        remaining_qty must always equal remaining_uom_qty exactly:
+        both go through the same "Product Unit of Measure" decimal
+        precision (whatever it is configured to in this database), so
+        any mismatch can only come from the extra UoM-rounding bug.
+        The reference UoM's rounding is deliberately set to a coarse,
+        unusual value (0.5) so the two fields are guaranteed to
+        disagree before the fix (1.00 - 0.633 = 0.367, which the old
+        code would round to the nearest 0.5 = 0.5, clearly different).
+        """
+        reference_uom = self.product.uom_id
+        reference_uom.rounding = 0.5
+        fine_uom = self.env["uom.uom"].create(
+            {
+                "name": "Fine Test Unit",
+                "category_id": reference_uom.category_id.id,
+                "uom_type": "smaller",
+                "factor": reference_uom.factor,
+                "rounding": 0.000001,
+            }
+        )
+        line = self.env["sale.blanket.order.line"].create(
+            {
+                "order_id": self.blanket.id,
+                "product_id": self.product.id,
+                "product_uom": fine_uom.id,
+                "original_uom_qty": 1.0,
+                "price_unit": self.product.lst_price,
+            }
+        )
+        sale_order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        self.env["sale.order.line"].create(
+            {
+                "order_id": sale_order.id,
+                "blanket_order_line": line.id,
+                "product_id": self.product.id,
+                "product_uom": fine_uom.id,
+                "product_uom_qty": 0.633,
+            }
+        )
+        line._compute_quantities()
+        self.assertEqual(line.remaining_qty, line.remaining_uom_qty)
+
     def test_00_full_workflow(self):
         """
         Test the full workflow of the custom sale blanket order,


### PR DESCRIPTION
@Escodoo/desenvolvedores 

[HT02034]


Problema relatado:

Ao fazer o pedido de venda temos o seguinte:

Quantidade: 1,00
Pedido de Venda: 0,633
Era para restar: 0,367

O Saldo é arredondado para: 0,36

O Odoo não respeita as casas decimais para atualizar os saldos, impossibilitando de dar sequenciamento nas medições.