### PR TITLE
[16.0][FIX] sale_blanket_order_revision: preserve quantity fields precision

### DIFF
--- a/sale_blanket_order_revision/models/sale_blanket_order_line.py
+++ b/sale_blanket_order_revision/models/sale_blanket_order_line.py
@@ -8,11 +8,13 @@ class SaleBlanketOrderLine(models.Model):
     _inherit = "sale.blanket.order.line"
 
     contracted_quantity = fields.Float(
+        digits="Product Unit of Measure",
         readonly=True,
         help="Total quantity contracted based on the associated order lines.",
     )
     initial_original_uom_qty = fields.Float(
         string="Initial Original Quantity",
+        digits="Product Unit of Measure",
         readonly=True,
         copy=False,
         help="Original quantity as first defined on the blanket order, "
@@ -20,6 +22,7 @@ class SaleBlanketOrderLine(models.Model):
         "never overwritten by later revisions or invoicing.",
     )
     accumulated_contracted_quantity = fields.Float(
+        digits="Product Unit of Measure",
         readonly=True,
         copy=False,
         help="Sum of the contracted quantity of this revision and all "


### PR DESCRIPTION
## Summary
- `sale_blanket_order_revision`: `contracted_quantity`, `initial_original_uom_qty` and `accumulated_contracted_quantity` had no `digits` set at all, defaulting to Odoo's built-in 2-decimal precision even though they are plain copies/sums of `original_uom_qty` (which uses a finer precision). Now use the same "Product Unit of Measure" decimal precision as `original_uom_qty`, so revisions do not silently lose precision.
